### PR TITLE
Small change to Animation class.

### DIFF
--- a/Source/Util/Animation.cpp
+++ b/Source/Util/Animation.cpp
@@ -48,9 +48,9 @@ const sf::IntRect& Animation::getFrame()
   //Restart timer
   m_timer.restart();
 
-  //Save overlapped time 
+  //Add remaining time to m_overlappedTime
   //(ie. what is left of 'totalElapsed' after subtracting all the frame delays)
-  m_overlappedTime = totalElapsed;
+  m_overlappedTime += totalElapsed;
 
 
   //Return the frame at the framepointer we ended up at

--- a/Source/Util/Animation.cpp
+++ b/Source/Util/Animation.cpp
@@ -21,20 +21,19 @@ void Animation::addFrame(unsigned index, sf::Time delay)
 //Returns the current/active frame of the animation
 const sf::IntRect& Animation::getFrame()
 {
-  //Get the elapsed time since last getFrame() call
-  //+ add the overlappedTime left from the previous getFrame() call
-  sf::Time totalElapsed = m_timer.getElapsedTime() + m_overlappedTime;
+  //Add the elapsed time since last getFrame() call to m_overlappedTime
+  m_overlappedTime += m_timer.getElapsedTime();
 
-  //Run while the elapsed time is greater than the current frames delay.
-  //This means that we may skip one or more frames if the elapsed time is 
+  //Run while the m_overlappedTime is greater than the current frames delay.
+  //This means that we may skip one or more frames if the m_overlappedTime is 
   //greater than the total delay of the skipped frames.
   //
   //(Previously we just incremented the framePoiner once if the elapsed time 
   // was greater than the first frames delay time)
-  while( totalElapsed >= m_frames[m_framePointer].delay )
+  while( m_overlappedTime >= m_frames[m_framePointer].delay )
   {
     //Subtract the frames delay time from the totalElapsed time
-    totalElapsed -= m_frames[m_framePointer].delay;
+    m_overlappedTime -= m_frames[m_framePointer].delay;
 
     //Increment framepointer
     m_framePointer++;
@@ -47,11 +46,6 @@ const sf::IntRect& Animation::getFrame()
 
   //Restart timer
   m_timer.restart();
-
-  //Add remaining time to m_overlappedTime
-  //(ie. what is left of 'totalElapsed' after subtracting all the frame delays)
-  m_overlappedTime += totalElapsed;
-
 
   //Return the frame at the framepointer we ended up at
   return m_frames[m_framePointer].bounds;

--- a/Source/Util/Animation.cpp
+++ b/Source/Util/Animation.cpp
@@ -37,16 +37,10 @@ const sf::IntRect& Animation::getFrame()
 
     //Increment framepointer
     m_framePointer++;
-
-    //Reset framepointer if it reaches end of vector
-    if(m_framePointer == m_frames.size())
-      m_framePointer = 0;
-
   }
 
   //Restart timer
   m_timer.restart();
 
-  //Return the frame at the framepointer we ended up at
-  return m_frames[m_framePointer].bounds;
+  return m_frames[ m_framePointer % m_frames.size() ].bounds;
 }

--- a/Source/Util/Animation.cpp
+++ b/Source/Util/Animation.cpp
@@ -21,12 +21,38 @@ void Animation::addFrame(unsigned index, sf::Time delay)
 //Returns the current/active frame of the animation
 const sf::IntRect& Animation::getFrame()
 {
-    if (m_timer.getElapsedTime() >= m_frames[m_framePointer].delay) {
-        m_timer.restart();
-        m_framePointer++;
-        if (m_framePointer == m_frames.size())
-            m_framePointer = 0;
-    }
+  //Get the elapsed time since last getFrame() call
+  //+ add the overlappedTime left from the previous getFrame() call
+  sf::Time totalElapsed = m_timer.getElapsedTime() + m_overlappedTime;
 
-    return m_frames[m_framePointer].bounds;
+  //Run while the elapsed time is greater than the current frames delay.
+  //This means that we may skip one or more frames if the elapsed time is 
+  //greater than the total delay of the skipped frames.
+  //
+  //(Previously we just incremented the framePoiner once if the elapsed time 
+  // was greater than the first frames delay time)
+  while( totalElapsed >= m_frames[m_framePointer].delay )
+  {
+    //Subtract the frames delay time from the totalElapsed time
+    totalElapsed -= m_frames[m_framePointer].delay;
+
+    //Increment framepointer
+    m_framePointer++;
+
+    //Reset framepointer if it reaches end of vector
+    if(m_framePointer == m_frames.size())
+      m_framePointer = 0;
+
+  }
+
+  //Restart timer
+  m_timer.restart();
+
+  //Save overlapped time 
+  //(ie. what is left of 'totalElapsed' after subtracting all the frame delays)
+  m_overlappedTime = totalElapsed;
+
+
+  //Return the frame at the framepointer we ended up at
+  return m_frames[m_framePointer].bounds;
 }

--- a/Source/Util/Animation.h
+++ b/Source/Util/Animation.h
@@ -24,6 +24,7 @@ class Animation
 
     private:
         sf::Clock m_timer;              //Timer for progressing the animation
+        sf::Time m_overlappedTime;      //Overlapped time from last getFrame() call
 
         std::vector<Frame> m_frames;    //List of animation frames
 


### PR DESCRIPTION
Previously getFrame() would only increment framePointer once even if
the time since last getFrame() call was greater than say the next 2 frame delays.

This commit makes getFrame() able to skip over multiple frames if the
elapsed time is greater than the skipped frames total delay. Making it
more accurate & independent from the games framerate.